### PR TITLE
Fix typo in `eval`

### DIFF
--- a/src/webview.cr
+++ b/src/webview.cr
@@ -87,7 +87,7 @@ module Webview
     # also the result of the expression is ignored. Use RPC bindings if you want
     # to receive notifications about the result of the evaluation.
     def eval(js : String)
-      LibWebView.init(@w, js)
+      LibWebView.eval(@w, js)
     end
 
     # binds a callback function so that it will appear under the given name


### PR DESCRIPTION
I believe this is an error, and `eval` here ought to be linked up to `LibWebview.eval`. However it's possible I've misunderstood something, and if so, please disregard.

Thanks for a really useful shard!