### PR TITLE
Updated webview library to latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,24 @@ Webview-supported platforms and the engines you can expect to render your applic
 
 | Operating System | Browser Engine Used |
 | ---------------- | ------------------- |
-| macOS            | Cocoa/WebKit        |
-| Linux            | Gtk-webkit2         |
-| Windows          | MSHTML or EdgeHTML  |
+| macOS            | Cocoa, [WebKit][webkit] |
+| Linux            | [GTK 3][gtk], [WebKitGTK][webkitgtk]|
+| Windows          | [Windows API][win32-api], [WebView2][ms-webview2]  |
 
 ## Pre-requisite
-If you're planning on targeting Linux you must ensure that Webkit2gtk is already installed and available for discovery via the pkg-config command.
+If you're planning on targeting Linux or BSD you must ensure that [WebKit2GTK][webkitgtk] is already installed and available for discovery via the pkg-config command.
 
+Debian-based systems:
+
+* Packages:
+  * Development: `apt install libgtk-3-dev libwebkit2gtk-4.0-dev`
+  * Production: `apt install libgtk-3-0 libwebkit2gtk-4.0-37`
+
+BSD-based systems:
+
+* FreeBSD packages: `pkg install webkit2-gtk3`
+* Execution on BSD-based systems may require adding the `wxallowed` option (see [mount(8)](https://man.openbsd.org/mount.8))  to your fstab to bypass [W^X](https://en.wikipedia.org/wiki/W%5EX "write xor execute") memory protection for your executable. Please see if it works without disabling this security feature first.
+  
 ## Installation
 
 1. Add the dependency to your `shard.yml`:
@@ -47,7 +58,7 @@ wv.destroy
 require "webview"
 
 html = <<-HTML
-data:text/html,<!DOCTYPE html><html lang="en-US">
+<!DOCTYPE html><html lang="en-US">
 <head>
 <title>Hello,World!</title>
 </head>
@@ -76,7 +87,8 @@ data:text/html,<!DOCTYPE html><html lang="en-US">
 </html>
 HTML
 
-wv = Webview.window(640, 480, Webview::SizeHints::NONE, "Hello WebView", html)
+wv = Webview.window(640, 480, Webview::SizeHints::NONE, "Hello WebView")
+wv.html = html
 wv.run
 wv.destroy
 ```
@@ -86,7 +98,7 @@ wv.destroy
 require "webview"
 
 html = <<-HTML
-data:text/html,<!doctype html>
+<!doctype html>
 <html>
   <body>hello</body>
   <script>
@@ -103,8 +115,8 @@ data:text/html,<!doctype html>
 </html>
 HTML
 
-wv = Webview.window(640, 480, Webview::SizeHints::NONE, "Hello WebView", html, true)
-
+wv = Webview.window(640, 480, Webview::SizeHints::NONE, "Hello WebView", true)
+wv.html = html
 wv.bind("noop", Webview::JSProc.new { |a|
   pp "Noop called with arguments: #{a}"
   JSON::Any.new("noop")
@@ -147,7 +159,8 @@ inject = <<-JS
   document.body.appendChild(elem);
 JS
 
-wv = Webview.window(640, 480, Webview::SizeHints::NONE, "Hello WebView", "data:text/html,#{html}" , true)
+wv = Webview.window(640, 480, Webview::SizeHints::NONE, "Hello WebView", true)
+wv.html = html
 
 wv.bind("add", Webview::JSProc.new { |n|
   wv.eval(sprintf(inject, n))
@@ -173,6 +186,60 @@ wv.run
 wv.destroy
 ```
 
+## App Distribution
+
+Distribution of your app is outside the scope of this library but we can give some pointers for you to explore.
+
+### macOS Application Bundle
+
+On macOS you would typically create a bundle for your app with an icon and proper metadata.
+
+A minimalistic bundle typically has the following directory structure:
+
+```
+example.app                 bundle
+└── Contents
+    ├── Info.plist          information property list
+    ├── MacOS
+    |   └── example         executable
+    └── Resources
+        └── example.icns    icon
+```
+
+Read more about the [structure of bundles][macos-app-bundle] at the Apple Developer site.
+
+> Tip: The `png2icns` tool can create icns files from PNG files. See the `icnsutils` package for Debian-based systems.
+
+### Windows Apps
+
+You would typically create a resource script file (`*.rc`) with information about the app as well as an icon. Since you should have MinGW-w64 readily available then you can compile the file using `windres` and link it into your program. If you instead use Visual C++ then look into the [Windows Resource Compiler][win32-rc].
+
+The directory structure could look like this:
+
+```
+my-project/
+├── icons/
+|   ├── application.ico
+|   └── window.ico
+├── basic.cc
+└── resources.rc
+```
+
+`resources.rc`:
+```
+100 ICON "icons\\application.ico"
+32512 ICON "icons\\window.ico"
+```
+
+> **Note:** The ID of the icon resource to be used for the window must be `32512` (`IDI_APPLICATION`).
+
+## Limitations
+
+### Browser Features
+
+Since a browser engine is not a full web browser it may not support every feature you may expect from a browser. If you find that a feature does not work as expected then please consult with the browser engine's documentation and [open an issue on webview library][issues-new] if you think that the library should support it.
+
+For example, the `webview` library does not attempt to support user interaction features like `alert()`, `confirm()` and `prompt()` and other non-essential features like `console.log()`.
 ## Contributing
 
 1. Fork it (<https://github.com/naqvis/webview/fork>)
@@ -184,3 +251,15 @@ wv.destroy
 ## Contributors
 
 - [Ali Naqvi](https://github.com/naqvis) - creator and maintainer
+
+
+[macos-app-bundle]:  https://developer.apple.com/library/archive/documentation/CoreFoundation/Conceptual/CFBundles/BundleTypes/BundleTypes.html
+[gtk]:               https://docs.gtk.org/gtk3/
+[issues-new]:        https://github.com/webview/webview/issues/new
+[webkit]:            https://webkit.org/
+[webkitgtk]:         https://webkitgtk.org/
+[ms-webview2]:       https://developer.microsoft.com/en-us/microsoft-edge/webview2/
+[ms-webview2-sdk]:   https://www.nuget.org/packages/Microsoft.Web.WebView2
+[ms-webview2-rt]:    https://developer.microsoft.com/en-us/microsoft-edge/webview2/
+[win32-api]:         https://docs.microsoft.com/en-us/windows/win32/apiindex/windows-api-list
+[win32-rc]:          https://docs.microsoft.com/en-us/windows/win32/menurc/resource-compiler

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: webview
-version: 0.1.5
+version: 0.2.0
 
 authors:
   - Ali Naqvi <syed.alinaqvi@gmail.com>

--- a/src/lib.cr
+++ b/src/lib.cr
@@ -45,7 +45,9 @@ module Webview
     # "data:text/text,<html>...</html>". It is often ok not to url-encode it
     # properly, webview will re-encode it for you.
     fun navigate = webview_navigate(w : T, url : LibC::Char*)
-
+    # Set webview HTML directly.
+    # Example: webview_set_html(w, "<h1>Hello</h1>");
+    fun set_html = webview_set_html(w : T, html : LibC::Char*)
     # Injects JavaScript code at the initialization of the new page. Every time
     # the webview will open a the new page - this initialization code will be
     # executed. It is guaranteed that code is executed before window.onload.
@@ -60,10 +62,35 @@ module Webview
     # string is a JSON array of all the arguments passed to the JavaScript
     # function.
     fun bind = webview_bind(w : T, name : LibC::Char*, fn : (LibC::Char*, LibC::Char*, Void* -> Void), arg : Void*)
+    # Removes a native C callback that was previously set by webview_bind.
+    fun unbind = webview_unbind(w : T, name : LibC::Char*)
     # Allows to return a value from the native binding. Original request pointer
     # must be provided to help internal RPC engine match requests with responses.
     # If status is zero - result is expected to be a valid JSON result value.
     # If status is not zero - result is an error JSON object.
     fun webview_return(w : T, seq : LibC::Char*, status : LibC::Int, result : LibC::Char*)
+    # Get the library's version information.
+    # @since 0.10
+    fun version = webview_version : WebviewVersionInfo*
+
+    # Holds the library's version information.
+    struct WebviewVersionInfo
+      # The elements of the version number.
+      version : WebviewVersion
+      # SemVer 2.0.0 version number in MAJOR.MINOR.PATCH format.
+      version_number : LibC::Char[32]
+      # SemVer 2.0.0 pre-release labels prefixed with "-" if specified, otherwise
+      # an empty string.
+      pre_release : LibC::Char[48]
+      # SemVer 2.0.0 build metadata prefixed with "+", otherwise an empty string.
+      build_metadata : LibC::Char[48]
+    end
+
+    # Holds the elements of a MAJOR.MINOR.PATCH version number.
+    struct WebviewVersion
+      major : LibC::UInt
+      minor : LibC::UInt
+      patch : LibC::UInt
+    end
   end
 end


### PR DESCRIPTION
* Updated `webview` to its latest version **0.10.0**
* Added new methods to `Webview` class
* Bumped Shard version to **0.20.0**

**Breaking Change**

`Webview.window` no longer works with `data:text/html`. Invoke `Webview#html` method to set the HTMLs. README examples are updated accordingly.