### PR TITLE
Webview.bind: Use to_json instead of to_s, README: fix examples

### DIFF
--- a/src/webview.cr
+++ b/src/webview.cr
@@ -118,7 +118,7 @@ module Webview
         cb_ctx = Box(BindContext).unbox(data)
         res = cb_ctx.cb.call(raw.as_a)
         @@bindings.delete(cb_ctx.cb)
-        LibWebView.webview_return(cb_ctx.w, id, 0, res.to_s)
+        LibWebView.webview_return(cb_ctx.w, id, 0, res.to_json)
       }, boxed)
     end
 


### PR DESCRIPTION
I think there is a bug in `Webview.bind`:

```crystal
    # binds a callback function so that it will appear under the given name
    # as a global Javascript function.
    def bind(name : String, fn : JSProc)
      ctx = BindContext.new(@w, fn)
      boxed = Box.box(ctx)
      @@bindings[fn] = boxed

      LibWebView.bind(@w, name, ->(id, req, data) {
        raw = JSON.parse(String.new(req))
        cb_ctx = Box(BindContext).unbox(data)
        res = cb_ctx.cb.call(raw.as_a)
        @@bindings.delete(cb_ctx.cb)
        LibWebView.webview_return(cb_ctx.w, id, 0, res.to_s) # <- BUG: should be to_json
      }, boxed)
    end
```
The return value is converted using `to_s` instead of `to_json`. The examples just work because they are using integers. But if you use strings it complains about missing functions (because the strings are not quoted and therefore interpreted as names). If you return a Hash it throws errors because of the `=>` symbol in the output generated by `to_s`.

This PR changes `to_s` to `to_json`.

In addition, i fixed the examples in the README. Several of them did not work because of the html not being passed to `Webview.window` or because the page couldn't load because of the missing `data:text/html,`.
