### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -22,6 +22,11 @@ jobs:
       - name: Install crystal land dependencies
         run: shards install
       - name: Compile library
-        run: make
+        shell: powershell
+        run: |
+          cd ext
+          cl /D "WEBVIEW_API=__declspec(dllexport)" /std:c++17 /EHsc webview.cc /link /DLL "/OUT:..\webview.dll"
+          cd ..
+          copy webview.lib (crystal env CRYSTAL_LIBRARY_PATH)
       - name: Run tests
         run: crystal spec

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Crystal
         uses: crystal-lang/install-crystal@v1
+      - name: Enable Developer Command Prompt
+        uses: ilammy/msvc-dev-cmd@cec98b9d092141f74527d0afa6feb2af698cfe89 # v1.12.1
       - name: Install Webview2 SDK
         run: |
           mkdir libs\webview2


### PR DESCRIPTION
This PR doesn't utilize makefile - instead it basically reimplements [build.bat](https://github.com/webview/webview/blob/master/script/build.bat)  from webview repository - it compiles webview to dll, copy dll to shard folder and copy lib to crystal `lib` folder.