### PR TITLE
Build and link with libwebview.a on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ ifeq ($(UNAME), Linux)
 	ar rcs ext/libwebview.a ext/webview.o
 endif
 
+ifeq ($(UNAME), Darwin)
+	ar rcs ext/libwebview.a ext/webview.o
+endif
+
 ifeq ($(findstring MINGW,$(UNAME)),MINGW)
 	ar rcs ext/libwebview.a ext/webview.o
 endif
@@ -33,4 +37,4 @@ endif
 
 .PHONY: clean
 clean:
-	rm -f $(obj_file)
+	rm -f $(obj_file) ext/libwebview.a

--- a/src/lib.cr
+++ b/src/lib.cr
@@ -1,7 +1,8 @@
 module Webview
   {% if flag?(:darwin) %}
+    @[Link(framework: "Cocoa")]
     @[Link(framework: "WebKit")]
-    @[Link(ldflags: "-L#{__DIR__}/../ext -lwebview.o -lc++")]
+    @[Link(ldflags: "#{__DIR__}/../ext/libwebview.a -lc++")]
   {% elsif flag?(:linux) %}
     @[Link(ldflags: "`command -v pkg-config > /dev/null &&
       if pkg-config --exists webkit2gtk-4.1; then


### PR DESCRIPTION
- Produce ext/libwebview.a on macOS
- Link against Cocoa and WebKit; stop linking .o directly
- Makefile clean removes the archive