### PR TITLE
fix(cocoa): guard deplete_run_loop_event_queue against non-main thread on macOS 26+

### DIFF
--- a/ext/webview.h
+++ b/ext/webview.h
@@ -2736,6 +2736,16 @@ private:
 
   // Blocks while depleting the run loop of events.
   void deplete_run_loop_event_queue() {
+    // nextEventMatchingMask: requires the OS main thread. On macOS 26+ this
+    // is enforced strictly — calling it off-main throws an ObjC exception that
+    // propagates as std::terminate. When the destructor is invoked from any
+    // thread other than the OS main thread (e.g. Crystal's preview_mt fiber
+    // pool, which parks Thread 0 and runs the app on a worker thread), skip
+    // the drain entirely. The window is already closed at this point, so
+    // skipping is safe.
+    if (!objc::msg_send<bool>("NSThread"_cls, "isMainThread"_sel)) {
+      return;
+    }
     objc::autoreleasepool arp;
     auto app = get_shared_application();
     bool done{};

--- a/spec/webview_spec.cr
+++ b/spec/webview_spec.cr
@@ -5,3 +5,47 @@ describe Webview do
     Webview::VERSION.should be_a(String)
   end
 end
+
+{% if flag?(:darwin) %}
+  # Regression guard for macOS 26+ (Tahoe) crashes in cocoa_wkwebview_engine
+  # when the destructor is invoked from a non-OS-main thread.
+  #
+  # Root cause: Crystal's preview_mt execution model parks Thread 0 (the OS
+  # main thread, where [NSThread isMainThread] returns true) in a condition
+  # variable and runs __crystal_main — including NSApp.run — on a worker
+  # thread. When the user closes the window, NSApp terminates, run() returns,
+  # and destroy() is called from that same worker thread.
+  #
+  # In this post-run state the window is already closed by NSApp (contentView
+  # has been cleared), so the early window-cleanup block in the destructor is
+  # a no-op. Control falls through to deplete_run_loop_event_queue(), which
+  # calls [NSApp nextEventMatchingMask:]. On macOS 26+ that method enforces
+  # [NSThread isMainThread] strictly: calling it from a non-main thread raises
+  # an ObjC exception that propagates as std::terminate → SIGABRT.
+  #
+  # Fix: guard deplete_run_loop_event_queue with an isMainThread check and
+  # return early when off-main. The drain is cosmetic at that point — the
+  # window is already gone.
+  #
+  # Note: the test below cannot fully reproduce the crash in a spec environment
+  # because calling destroy() before run() leaves the window's contentView
+  # intact, triggering a *different* off-main AppKit violation in WebKit's
+  # WKWindowVisibilityObserver. The real crash occurs specifically in the
+  # post-run state where NSApp has already closed the window. The fix is
+  # verified by running an actual Lune app under preview_mt on macOS 26+.
+  describe "macOS 26+ destroy safety" do
+    it "Webview#destroy is defined and callable (compile check)" do
+      # Verify the method exists. Full runtime validation of the off-main
+      # destructor path requires a live NSApp event loop (see comment above).
+      typeof(Webview::Webview.allocate.destroy)
+    end
+
+    pending "destroy called from non-main Thread after NSApp lifecycle does not crash" do
+      # To reproduce: create a webview, call run (NSApp event loop starts),
+      # close the window (terminate called), then call destroy from the worker
+      # thread that ran the loop. Without the isMainThread guard, this aborts
+      # via std::terminate. Cannot be automated in crystal spec because run()
+      # blocks and requires an interactive display session.
+    end
+  end
+{% end %}


### PR DESCRIPTION
## Problem

macOS 26 (Tahoe) tightened enforcement of `nextEventMatchingMask:untilDate:inMode:dequeue:` to require `[NSThread isMainThread] == true`. Calling it from any other thread now raises an ObjC exception which, lacking a `catch` handler in the C++ destructor, propagates as `std::terminate` → `SIGABRT`.

This surfaces when using Crystal's `preview_mt` execution model (`-Dpreview_mt -Dexecution_context`), which parks **Thread 0** (the OS main thread) in a condition variable and runs `__crystal_main` — including `NSApp.run` — on a worker thread. After the window closes and `run()` returns, `destroy()` is called from that same worker thread. The destructor reaches `deplete_run_loop_event_queue()` and crashes.

Crash trace (macOS 26.3.1, ARM64):
```
Thread 14 Crashed:
0   libsystem_c.dylib           abort + 124
1   libc++abi.dylib             demangling_terminate_handler()
2   libobjc.A.dylib             _objc_terminate()
3   libc++abi.dylib             std::terminate()
4   main                        cocoa_wkwebview_engine::deplete_run_loop_event_queue() + 312
5   main                        cocoa_wkwebview_engine::~cocoa_wkwebview_engine() + 852
6   main                        webview_destroy + 32
```

## Fix

Add an `[NSThread isMainThread]` guard at the top of `deplete_run_loop_event_queue()`. When called from a non-main thread, return early.

This is safe because by the time the destructor reaches this function, NSApp has already handled the `close:` sequence and the window is gone. The drain is purely cosmetic (ensures the window disappears immediately on screen) and has no correctness impact when skipped.

```cpp
void deplete_run_loop_event_queue() {
    if (!objc::msg_send<bool>("NSThread"_cls, "isMainThread"_sel)) {
      return;
    }
    // ... existing drain loop
}
```

## Notes

- The crash only manifests on **macOS 26+**; earlier versions tolerate the off-main call.
- It only affects runtimes that do not park the app on Thread 0 (e.g. Crystal `preview_mt`, potentially other multi-threaded environments).
- A runtime test requires a live `NSApp` event loop lifecycle and cannot be automated in `crystal spec`; the spec includes a `pending` example with the full reproduction steps documented.
